### PR TITLE
Rename AirbyteLib to PyAirbyte in quickstarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ venv.bak/
 #Desktop Services Store
 .DS_Store
 
-# AirbyteLib caches and virtual environments
+# PyAirbyte caches and virtual environments
 .cache
 .venv*

--- a/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_Basic_Features_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {

--- a/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_Basic_Features_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_Basic_Features_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {

--- a/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_Basic_Features_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {
@@ -16,9 +16,9 @@
         "id": "R8XtHKK4PujA"
       },
       "source": [
-        "# AirbyteLib Demo\n",
+        "# PyAirbyte Demo\n",
         "\n",
-        "Below is a pre-release demo of AirbyteLib.\n"
+        "Below is a pre-release demo of PyAirbyte.\n"
       ]
     },
     {
@@ -27,7 +27,7 @@
         "id": "Lyxh2NLuQJUf"
       },
       "source": [
-        "## Install AirbyteLib\n"
+        "## Install PyAirbyte\n"
       ]
     },
     {
@@ -41,8 +41,8 @@
         "# Add virtual environment support for running in Google Colab\n",
         "!apt-get install -qq python3.10-venv\n",
         "\n",
-        "# Install airbyte-lib\n",
-        "%pip install --quiet airbyte-lib"
+        "# Install PyAirbyte\n",
+        "%pip install --quiet airbyte"
       ]
     },
     {
@@ -64,8 +64,8 @@
       },
       "outputs": [],
       "source": [
-        "# Import AirbyteLib\n",
-        "import airbyte_lib as ab\n",
+        "# Import PyAirbyte\n",
+        "import airbyte as ab\n",
         "\n",
         "# Show all available connectors\n",
         "ab.get_available_connectors()"
@@ -77,7 +77,7 @@
         "id": "JWWeEbTVEDFz"
       },
       "source": [
-        "## Load the Source Data using AirbyteLib\n"
+        "## Load the Source Data using PyAirbyte\n"
       ]
     },
     {
@@ -139,7 +139,7 @@
         }
       ],
       "source": [
-        "import airbyte_lib as ab\n",
+        "import airbyte as ab\n",
         "\n",
         "# Create and install the source:\n",
         "source: ab.Source = ab.get_source(\"source-faker\")"
@@ -189,7 +189,7 @@
         "id": "Que5DAqtEJu0"
       },
       "source": [
-        "## Read Data from the AirbyteLib Cache\n",
+        "## Read Data from the PyAirbyte Cache\n",
         "\n",
         "Once data is read, we can do anything we want to with the resulting streams. This includes `to_pandas()` which registers a Pandas dataframe and `to_sql_table()` which gives us a SQLAlchemy `Table` boject, which we can use to run SQL queries.\n"
       ]
@@ -678,7 +678,7 @@
       "source": [
         "## Creating graphs\n",
         "\n",
-        "AirbyteLib integrates with Pandas, which integrates with `matplotlib` as well as many other popular libraries. We can use this as a means of quickly creating graphs.\n"
+        "PyAirbyte integrates with Pandas, which integrates with `matplotlib` as well as many other popular libraries. We can use this as a means of quickly creating graphs.\n"
       ]
     },
     {
@@ -996,10 +996,10 @@
               "            <td>users</td>\n",
               "        </tr>\n",
               "        <tr>\n",
-              "            <td>_airbytelib_state</td>\n",
+              "            <td>_PyAirbyte_state</td>\n",
               "        </tr>\n",
               "        <tr>\n",
-              "            <td>_airbytelib_streams</td>\n",
+              "            <td>_PyAirbyte_streams</td>\n",
               "        </tr>\n",
               "    </tbody>\n",
               "</table>"
@@ -1011,8 +1011,8 @@
               "|       products      |\n",
               "|      purchases      |\n",
               "|        users        |\n",
-              "|  _airbytelib_state  |\n",
-              "| _airbytelib_streams |\n",
+              "|  _PyAirbyte_state  |\n",
+              "| _PyAirbyte_streams |\n",
               "+---------------------+"
             ]
           },

--- a/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_CoinAPI_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_CoinAPI_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {

--- a/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_CoinAPI_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {

--- a/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_CoinAPI_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {
@@ -16,7 +16,7 @@
         "id": "En5baAhvYE_y"
       },
       "source": [
-        "In this demo, we use `airbyte-lib` to extract cryptocurrency data from [CoinAPI.io](https://www.coinapi.io/), followed by a series of transformations and analyses to derive meaningful insights from this data.\n",
+        "In this demo, we use PyAirbyte to extract cryptocurrency data from [CoinAPI.io](https://www.coinapi.io/), followed by a series of transformations and analyses to derive meaningful insights from this data.\n",
         "\n",
         "The only prerequisite is a CoinAPI [API key](https://www.coinapi.io/get-free-api-key?product_id=market-data-api).\n"
       ]
@@ -27,7 +27,7 @@
         "id": "8awBDcLvRW2g"
       },
       "source": [
-        "### Installing AirbyteLib\n"
+        "### Installing PyAirbyte\n"
       ]
     },
     {
@@ -41,8 +41,8 @@
         "# Add virtual environment support in Google Colab\n",
         "!apt-get install -qq python3.10-venv\n",
         "\n",
-        "# Install airbyte-lib\n",
-        "%pip install --quiet airbyte-lib"
+        "# Install PyAirbyte\n",
+        "%pip install --quiet airbyte"
       ]
     },
     {
@@ -53,7 +53,7 @@
       "source": [
         "### Load source data from CoinAPI.io to local cache\n",
         "\n",
-        "In this section, we establish a connection to CoinAPI.io to access cryptocurrency data via airbyte-lib. The connector is configured with necessary parameters like the API key, environment setting, symbol ID for the specific cryptocurrency index (in this case, `COINBASE_SPOT_INDEX_USD`), and the data period we are interested in. [Check the docs](https://docs.airbyte.com/integrations/sources/coin-api) for more details.\n",
+        "In this section, we establish a connection to CoinAPI.io to access cryptocurrency data via PyAirbyte. The connector is configured with necessary parameters like the API key, environment setting, symbol ID for the specific cryptocurrency index (in this case, `COINBASE_SPOT_INDEX_USD`), and the data period we are interested in. [Check the docs](https://docs.airbyte.com/integrations/sources/coin-api) for more details.\n",
         "\n",
         "After configuring the source connector, we perform a check to ensure that the configuration is correct and the connection to the API is successful. Then, we proceed to read from the source into the internal DuckDB cache. The `read()` retrieves all available streams from the source.\n",
         "\n",
@@ -68,7 +68,7 @@
       },
       "outputs": [],
       "source": [
-        "import airbyte_lib as ab\n",
+        "import airbyte as ab\n",
         "\n",
         "# Create and configure the source connector:\n",
         "source = ab.get_source(\n",

--- a/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_GA4_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {

--- a/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_GA4_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {
@@ -16,7 +16,7 @@
         "id": "En5baAhvYE_y"
       },
       "source": [
-        "In this demo, we use `airbyte-lib` to extract data from Google Analytics 4, followed by a series of transformations and analyses to derive meaningful insights from this data.\n",
+        "In this demo, we use PyAirbyte to extract data from Google Analytics 4, followed by a series of transformations and analyses to derive meaningful insights from this data.\n",
         "\n",
         "#### Prerequisites:\n",
         "\n",
@@ -29,7 +29,7 @@
         "id": "8awBDcLvRW2g"
       },
       "source": [
-        "### Installing AirbyteLib\n"
+        "### Installing PyAirbyte\n"
       ]
     },
     {
@@ -43,8 +43,8 @@
         "# Add virtual environment support in Google Colab\n",
         "!apt-get install -qq python3.10-venv\n",
         "\n",
-        "# Install airbyte-lib\n",
-        "%pip install airbyte-lib"
+        "# Install PyAirbyte\n",
+        "%pip install airbyte"
       ]
     },
     {
@@ -55,7 +55,7 @@
       "source": [
         "### Load source data from Google Analytics 4 to local cache\n",
         "\n",
-        "In this section, we establish a connection to GA4 via `airbyte-lib`. The source connector is configured with necessary parameters like the GA4 property ID, the service account JSON key, and the data period we are interested in. Check the [docs](https://docs.airbyte.com/integrations/sources/google-analytics-data-api) for more details on these parameters.\n",
+        "In this section, we establish a connection to GA4 via PyAirbyte. The source connector is configured with necessary parameters like the GA4 property ID, the service account JSON key, and the data period we are interested in. Check the [docs](https://docs.airbyte.com/integrations/sources/google-analytics-data-api) for more details on these parameters.\n",
         "\n",
         "After configuring the source connector, we perform a `check()` to ensure that the configuration is correct and the connection to the API is successful. Then, we list the available streams for this source and select the ones we are interested in syncing. In this case, we are only syncing the `pages` stream.\n",
         "\n",
@@ -129,7 +129,7 @@
         }
       ],
       "source": [
-        "import airbyte_lib as ab\n",
+        "import airbyte as ab\n",
         "\n",
         "# Create and configure the source connector:\n",
         "source = ab.get_source(\n",

--- a/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_GA4_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_GA4_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {

--- a/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_Github_Incremental_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {
@@ -16,7 +16,7 @@
         "id": "gS3oGgI0CVpn"
       },
       "source": [
-        "In this demo, we use `airbyte-lib` to extract data from Github, followed by a series of transformations and analyses to derive meaningful insights from this data. In particular, we demonstrate `airbyte-lib` capabilities for extracting data incrementally.\n",
+        "In this demo, we use PyAirbyte to extract data from Github, followed by a series of transformations and analyses to derive meaningful insights from this data. In particular, we demonstrate PyAirbyte capabilities for extracting data incrementally.\n",
         "\n",
         "#### Prerequisites:\n",
         "\n",
@@ -34,8 +34,8 @@
         "# Add virtual environment support in Google Colab\n",
         "!apt-get install -qq python3.10-venv\n",
         "\n",
-        "# Install airbyte-lib\n",
-        "%pip install --quiet airbyte-lib"
+        "# Install airbyte\n",
+        "%pip install --quiet airbyte"
       ]
     },
     {
@@ -46,7 +46,7 @@
       "source": [
         "### Load source data from Github to local cache\n",
         "\n",
-        "In this section, we establish a connection to Github via `airbyte-lib`. The source connector is configured with necessary parameters like the credentials repository we are interested in. Check the [docs](https://docs.airbyte.com/integrations/sources/github) for more details on these parameters.\n",
+        "In this section, we establish a connection to Github via PyAirbyte. The source connector is configured with necessary parameters like the credentials repository we are interested in. Check the [docs](https://docs.airbyte.com/integrations/sources/github) for more details on these parameters.\n",
         "\n",
         "After configuring the source connector, we perform a `check()` to ensure that the configuration is correct and the connection to the API is successful. Then, we list the available streams for this source and select the ones we are interested in syncing.\n",
         "\n",
@@ -118,7 +118,7 @@
         }
       ],
       "source": [
-        "import airbyte_lib as ab\n",
+        "import airbyte as ab\n",
         "\n",
         "# Create and configure the source:\n",
         "source = ab.get_source(\n",
@@ -281,7 +281,7 @@
       "source": [
         "### Read again to sync changes\n",
         "\n",
-        "The `airbyte-lib` Github source connector has the ability to read data incrementally by default, meaning that after the first successful data sync, only updates and new records will be synced in subsequent reads.\n",
+        "The PyAirbyte Github source connector has the ability to read data incrementally by default, meaning that after the first successful data sync, only updates and new records will be synced in subsequent reads.\n",
         "\n",
         "For more information on sync modes for this source, you can refer to the [docs](https://docs.airbyte.com/integrations/sources/github).\n",
         "\n",

--- a/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_Github_Incremental_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {

--- a/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb
+++ b/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
       ]
     },
     {

--- a/airbyte_lib_notebooks/README.md
+++ b/airbyte_lib_notebooks/README.md
@@ -1,17 +1,17 @@
-# AirbyteLib Notebooks Quickstart
+# PyAirbyte Notebooks Quickstart
 
-This quickstart will help you get started quickly with AirbyteLib.
+This quickstart will help you get started quickly with PyAirbyte.
 
-> **Note:** **AirbyteLib is currently in private beta and is not intended for production use.**
+> **Note:** **PyAirbyte is currently in private beta and is not intended for production use.**
 
 ## Quickstart Quicklinks
 
 To jump right in, click on any of the below links to open a new Colab notebook from the provided quickstart template.
 
-1. [Basic Features Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb) - Walks through the basic functionality of AirbyteLib and how to use it in a Notebook environment.
-2. [CoinAPI Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb) - Shows how to provide credentials securely and perform basic graphing.
-3. [GitHub Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb) - Demonstrates how to get data from GitHub, how to analyze GitHub metrics and how to refresh your cache data incrementally.
-4. [GA4 Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb) - A Google Analytics demo showing how to analyze page views and other GA metrics.
+1. [Basic Features Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_Basic_Features_Demo.ipynb) - Walks through the basic functionality of PyAirbyte and how to use it in a Notebook environment.
+2. [CoinAPI Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_CoinAPI_Demo.ipynb) - Shows how to provide credentials securely and perform basic graphing.
+3. [GitHub Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_Github_Incremental_Demo.ipynb) - Demonstrates how to get data from GitHub, how to analyze GitHub metrics and how to refresh your cache data incrementally.
+4. [GA4 Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_GA4_Demo.ipynb) - A Google Analytics demo showing how to analyze page views and other GA metrics.
 
 ## How to use these Quickstarts
 
@@ -35,7 +35,7 @@ You can run these notebooks natively in VS Code if you have the Python extension
 
 ## Securely Managed Secrets
 
-You can pass secrets to AirbyteLib by using the `get_secret()` function. This call will retrieve a named secret from any of the following locations:
+You can pass secrets to PyAirbyte by using the `get_secret()` function. This call will retrieve a named secret from any of the following locations:
 
 1. Google Colab Secrets
 2. Environment Variables
@@ -43,6 +43,6 @@ You can pass secrets to AirbyteLib by using the `get_secret()` function. This ca
 
 If you are using Google Colab, we suggest using the Colab secrets feature. For other environments, you can set your secret values in environment variables.
 
-Note: The `get_secret()` implementation in AirbyteLib is provided for your convenience as a secure runtime-agnostic default secrets interface. You are always free to use any secrets management platform you are most familiar with.
+Note: The `get_secret()` implementation in PyAirbyte is provided for your convenience as a secure runtime-agnostic default secrets interface. You are always free to use any secrets management platform you are most familiar with.
 
 **Warning:** Please do not enter your secrets directly into notebook cells. Doing so can cause the secret to be leaked into logs and/or in the "previous versions" look-back of the notebook. Instead, simply call `get_secret()` without pre-initializing the value. If the value is not already initialized, you will be prompted for secret values interactively and all values will be masked during input to avoid accidental leakage. This is performed using the Python standard library [`getpass`](https://docs.python.org/3/library/getpass.html).

--- a/airbyte_lib_notebooks/README.md
+++ b/airbyte_lib_notebooks/README.md
@@ -8,10 +8,10 @@ This quickstart will help you get started quickly with PyAirbyte.
 
 To jump right in, click on any of the below links to open a new Colab notebook from the provided quickstart template.
 
-1. [Basic Features Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_Basic_Features_Demo.ipynb) - Walks through the basic functionality of PyAirbyte and how to use it in a Notebook environment.
-2. [CoinAPI Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_CoinAPI_Demo.ipynb) - Shows how to provide credentials securely and perform basic graphing.
-3. [GitHub Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_Github_Incremental_Demo.ipynb) - Demonstrates how to get data from GitHub, how to analyze GitHub metrics and how to refresh your cache data incrementally.
-4. [GA4 Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/PyAirbyte_GA4_Demo.ipynb) - A Google Analytics demo showing how to analyze page views and other GA metrics.
+1. [Basic Features Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_Basic_Features_Demo.ipynb) - Walks through the basic functionality of PyAirbyte and how to use it in a Notebook environment.
+2. [CoinAPI Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_CoinAPI_Demo.ipynb) - Shows how to provide credentials securely and perform basic graphing.
+3. [GitHub Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb) - Demonstrates how to get data from GitHub, how to analyze GitHub metrics and how to refresh your cache data incrementally.
+4. [GA4 Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_GA4_Demo.ipynb) - A Google Analytics demo showing how to analyze page views and other GA metrics.
 
 ## How to use these Quickstarts
 

--- a/airbyte_lib_notebooks/README.md
+++ b/airbyte_lib_notebooks/README.md
@@ -8,10 +8,10 @@ This quickstart will help you get started quickly with PyAirbyte.
 
 To jump right in, click on any of the below links to open a new Colab notebook from the provided quickstart template.
 
-1. [Basic Features Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_Basic_Features_Demo.ipynb) - Walks through the basic functionality of PyAirbyte and how to use it in a Notebook environment.
-2. [CoinAPI Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_CoinAPI_Demo.ipynb) - Shows how to provide credentials securely and perform basic graphing.
-3. [GitHub Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb) - Demonstrates how to get data from GitHub, how to analyze GitHub metrics and how to refresh your cache data incrementally.
-4. [GA4 Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_notebooks/AirbyteLib_GA4_Demo.ipynb) - A Google Analytics demo showing how to analyze page views and other GA metrics.
+1. [Basic Features Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_Basic_Features_Demo.ipynb) - Walks through the basic functionality of PyAirbyte and how to use it in a Notebook environment.
+2. [CoinAPI Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_CoinAPI_Demo.ipynb) - Shows how to provide credentials securely and perform basic graphing.
+3. [GitHub Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_Github_Incremental_Demo.ipynb) - Demonstrates how to get data from GitHub, how to analyze GitHub metrics and how to refresh your cache data incrementally.
+4. [GA4 Demo](https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/airbyte_lib_notebooks/AirbyteLib_GA4_Demo.ipynb) - A Google Analytics demo showing how to analyze page views and other GA metrics.
 
 ## How to use these Quickstarts
 


### PR DESCRIPTION
This PR makes the necessary renames from AirbyteLib to PyAirbyte, including related changes:

- Install from `airbyte` instead of `airbyte-lib`.
- Import from `airbyte` instead of `airbyte_lib`.

Note: I have not changed the file names or paths because they are hard-coded in a few places and (for now) I'd like to prevent breaking any links.