### PR TITLE
Docs: Added quickdstart showing to_documents() usage followed by RAG with langchain 

### DIFF
--- a/pyairbyte_notebooks/PyAirbyte_Document_Creation_RAG_with_Langchain_Demo.ipynb
+++ b/pyairbyte_notebooks/PyAirbyte_Document_Creation_RAG_with_Langchain_Demo.ipynb
@@ -1,0 +1,279 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/airbytehq/quickstarts/blob/master/pyairbyte_notebooks/PyAirbyte_Document_Creation_RAG_with_Langchain_Demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "y4_-FI2aLFYP"
+      },
+      "source": [
+        "# PyAirbyte Demo\n",
+        "\n",
+        "This demo uses the PyAirbyte libary to read records from Github, converts those records to documents, which can then be passed to LangChain for RAG.\n",
+        "\n",
+        "#### Prerequisites:\n",
+        "\n",
+        "-   A Github personal access token. For details on configuring authetication credentials, refer to the Github source connector [documentation](https://docs.airbyte.com/integrations/sources/github).\n",
+        "\n",
+        "-   OpenAI API Key. You can create one by signing up on https://openai.com/ and\n",
+        "going to the \"Keys\" tab on left sidebar."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LZ5mUBw_g2kT"
+      },
+      "source": [
+        "## Install PyAirbyte and other dependencies\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "kZjfRtSGoQHJ"
+      },
+      "outputs": [],
+      "source": [
+        "# Add virtual environment support for running in Google Colab\n",
+        "!apt-get install -qq python3.10-venv\n",
+        "\n",
+        "# Install PyAirbyte & Langchain modules\n",
+        "%pip install --quiet airbyte langchain langchain_openai langchainhub chromadb"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3MtTFRoYg6bP"
+      },
+      "source": [
+        "## Load the Source Data using PyAirbyte\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "TEzG3kXznVtz"
+      },
+      "outputs": [],
+      "source": [
+        "import airbyte as ab\n",
+        "\n",
+        "# Configure and read from the source\n",
+        "read_result = ab.get_source(\n",
+        "    \"source-github\",\n",
+        "    config={\n",
+        "        \"repositories\": [\"airbytehq/pyAirbyte\"],\n",
+        "        \"credentials\": {\n",
+        "            \"personal_access_token\": ab.get_secret(\"GITHUB_PERSONAL_ACCESS_TOKEN\")\n",
+        "\n",
+        "        }\n",
+        "    },\n",
+        "    streams=[\"issues\"],\n",
+        ").read()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nM4mWwmkhLS_"
+      },
+      "source": [
+        "## Read a single record from stream to examine the fields"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "kj1u-znnuYKu"
+      },
+      "outputs": [],
+      "source": [
+        "first_record = next((record for record in read_result[\"issues\"]))\n",
+        "\n",
+        "# Print the fields list, followed by the first full record.\n",
+        "display(list(first_record.keys()))\n",
+        "display(first_record)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZiGGcJdUjnsf"
+      },
+      "source": [
+        "## Use PyAirbyte `to_documents()` method on a dataset\n",
+        "\n",
+        "This demo uses a new `to_documents()` method, which accepts record property names which point to specific aspects of the document.\n",
+        "\n",
+        "When we set `render_metadata=True`, then metadata properties are also published to the markdown file. This option is helpful for small-ish documents, when passing the entire document to the LLM. It will be less helpful on long documents which are planned to be split into smaller chuns.\n",
+        "\n",
+        "Note: We use `rich` to print the documents as markdown, although that's not strictly necessary.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "TmA_bF6rjoXy"
+      },
+      "outputs": [],
+      "source": [
+        "import textwrap\n",
+        "from rich.console import Console\n",
+        "\n",
+        "# convert incoming stream data into documents\n",
+        "docs = list(read_result[\"issues\"].to_documents(\n",
+        "    title_property=\"title\",\n",
+        "    content_properties=[\"body\"],\n",
+        "    metadata_properties=[\"state\", \"url\", \"number\"],\n",
+        "    render_metadata=True,\n",
+        "))\n",
+        "\n",
+        "# print a doc comprising github issue\n",
+        "console = Console()\n",
+        "console.print(str(docs[10]))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0mkPWz8NkTbH"
+      },
+      "source": [
+        "## Use Langchain to build a RAG pipeline.\n",
+        "\n",
+        "Here, we just show a generic method of splitting docs. This and the following steps are copied from a generic LangChain tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "s1mFwmOGkNqe"
+      },
+      "outputs": [],
+      "source": [
+        "# Split the docs so they can be stored in vector database downstream\n",
+        "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+        "\n",
+        "splitter = RecursiveCharacterTextSplitter(chunk_size=512, chunk_overlap=30)\n",
+        "\n",
+        "chunked_docs = splitter.split_documents(docs)\n",
+        "\n",
+        "print(f\"Created {len(chunked_docs)} document chunks.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SdRovb3c1eoH"
+      },
+      "source": [
+        "Now we can publish the chunks to a vector store. Ensure you have added your `OPENAI_API_KEY` to the secrects tab on left."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Lj7rXrF417tX"
+      },
+      "outputs": [],
+      "source": [
+        "from langchain_community.vectorstores import Chroma\n",
+        "from langchain_openai import OpenAIEmbeddings\n",
+        "import os\n",
+        "\n",
+        "os.environ['OPENAI_API_KEY'] = ab.get_secret(\"OPENAI_API_KEY\")\n",
+        "\n",
+        "# store into vector db\n",
+        "vectorstore = Chroma.from_documents(documents=chunked_docs, embedding=OpenAIEmbeddings())\n",
+        "print(\"Chunks successfully stored in vectorstore.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MSP8TgBf38VN"
+      },
+      "source": [
+        "Set up a RAG application using LangChain."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "kaamV9Q93v52"
+      },
+      "outputs": [],
+      "source": [
+        "from langchain_openai import ChatOpenAI\n",
+        "from langchain import hub\n",
+        "from langchain_core.output_parsers import StrOutputParser\n",
+        "from langchain_core.runnables import RunnablePassthrough\n",
+        "\n",
+        "retriever = vectorstore.as_retriever()\n",
+        "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+        "llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0)\n",
+        "\n",
+        "\n",
+        "def format_docs(docs):\n",
+        "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
+        "\n",
+        "rag_chain = (\n",
+        "    {\"context\": retriever | format_docs, \"question\": RunnablePassthrough()}\n",
+        "    | prompt\n",
+        "    | llm\n",
+        "    | StrOutputParser()\n",
+        ")\n",
+        "print(\"Langchain RAG pipeline set up successfully.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3eDeZ6-74DH7"
+      },
+      "source": [
+        "Ask a question."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "_haRAZyJ4Gjf"
+      },
+      "outputs": [],
+      "source": [
+        "console.print(rag_chain.invoke(\"Show me all documentation related issues, along with issue number, each on a new line.\"))"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
Related to https://github.com/airbytehq/PyAirbyte/issues/70

This quickstart illustrates the PyAirbyte-centric approach to using langchain and is based on https://colab.research.google.com/drive/1IiP224qBttdSVYA31mutgokDsMk-1DAq with following changes.
* We are only showing one way to convert to documents here: to_documents()
* Added code for vector db storage and retrieval 
* Clean up comments/added more documention