### PR TITLE
Docs: Update Postgres API used by TF Provider

### DIFF
--- a/airbyte_dbt_airflow_snowflake/infra/airbyte/main.tf
+++ b/airbyte_dbt_airflow_snowflake/infra/airbyte/main.tf
@@ -13,19 +13,13 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
         replication_method = {
-            source_postgres_update_method_scan_changes_with_user_defined_cursor = {
-                method = "Standard"
-            }
+            scan_changes_with_user_defined_cursor = {}
         }
     }
     name = "Postgres"

--- a/airbyte_dbt_dagster/infra/airbyte/main.tf
+++ b/airbyte_dbt_dagster/infra/airbyte/main.tf
@@ -13,20 +13,12 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
-        replication_method = {
-            source_postgres_replication_method_standard = {
-                method = "Standard"
-            }
-        }
+        replication_method = {}
     }
     name = "Postgres"
     workspace_id = var.workspace_id

--- a/airbyte_dbt_prefect_snowflake/infra/airbyte/main.tf
+++ b/airbyte_dbt_prefect_snowflake/infra/airbyte/main.tf
@@ -13,19 +13,13 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
         replication_method = {
-            source_postgres_update_method_scan_changes_with_user_defined_cursor = {
-                method = "Standard"
-            }
+            scan_changes_with_user_defined_cursor = {}
         }
     }
     name = "Postgres"

--- a/airbyte_dbt_snowflake_looker/infra/airbyte/main.tf
+++ b/airbyte_dbt_snowflake_looker/infra/airbyte/main.tf
@@ -13,19 +13,13 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
         replication_method = {
-            source_postgres_update_method_scan_changes_with_user_defined_cursor = {
-                method = "Standard"
-            }
+            scan_changes_with_user_defined_cursor = {}
         }
     }
     name = "Postgres"

--- a/database_snapshot/infra/airbyte/sources/main.tf
+++ b/database_snapshot/infra/airbyte/sources/main.tf
@@ -13,19 +13,13 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
         replication_method = {
-            source_postgres_update_method_scan_changes_with_user_defined_cursor = {
-                method = "Standard"
-            }
+            scan_changes_with_user_defined_cursor = {}
         }
     }
     name = "Postgres"

--- a/low_latency_data_availability/infra/airbyte/main.tf
+++ b/low_latency_data_availability/infra/airbyte/main.tf
@@ -13,18 +13,13 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
         replication_method = {
-            source_postgres_update_method_read_changes_using_write_ahead_log_cdc = {
-                method = "CDC"
+            read_changes_using_write_ahead_log_cdc = {
                 publication = "...pub..."
                 replication_slot = "...slot..."
             }

--- a/mysql_to_postgres_incremental_stack/infra/airbyte/main.tf
+++ b/mysql_to_postgres_incremental_stack/infra/airbyte/main.tf
@@ -33,15 +33,12 @@ resource "airbyte_destination_postgres" "my_destination_postgres" {
     password         = "...my_password..."
     port             = 5432
     schema           = "public"
+    ssl              = true
     ssl_mode = {
-      destination_postgres_ssl_modes_allow = {
-        mode = "allow"
-      }
+      allow = {}
     }
     tunnel_method = {
-      destination_postgres_ssh_tunnel_method_no_tunnel = {
-        tunnel_method = "NO_TUNNEL"
-      }
+      no_tunnel = {}
     }
     username = "...my_username..."
   }

--- a/postgres_data_replication/infra/airbyte/main.tf
+++ b/postgres_data_replication/infra/airbyte/main.tf
@@ -13,18 +13,13 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
         replication_method = {
-            source_postgres_update_method_read_changes_using_write_ahead_log_cdc = {
-                method = "CDC"
+            read_changes_using_write_ahead_log_cdc = {
                 publication = "...pub..."
                 replication_slot = "...slot..."
             }

--- a/postgres_snowflake_integration/infra/airbyte/main.tf
+++ b/postgres_snowflake_integration/infra/airbyte/main.tf
@@ -13,18 +13,13 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
         replication_method = {
-            source_postgres_update_method_read_changes_using_write_ahead_log_cdc = {
-                method = "CDC"
+            read_changes_using_write_ahead_log_cdc = {
                 publication = "...pub..."
                 replication_slot = "...slot..."
             }

--- a/postgres_to_mysql_migration/infra/airbyte/main.tf
+++ b/postgres_to_mysql_migration/infra/airbyte/main.tf
@@ -13,18 +13,13 @@ resource "airbyte_source_postgres" "postgres" {
             "...my_schema..."
         ]
         ssl_mode = {
-            source_postgres_ssl_modes_allow = {
-                mode = "allow"
-            }
+            allow = {}
         }
         tunnel_method = {
-            source_postgres_ssh_tunnel_method_no_tunnel = {
-                tunnel_method = "NO_TUNNEL"
-            }
+            no_tunnel = {}
         }
         replication_method = {
-            source_postgres_update_method_read_changes_using_write_ahead_log_cdc = {
-                method = "CDC"
+            read_changes_using_write_ahead_log_cdc = {
                 publication = "...pub..."
                 replication_slot = "...slot..."
             }


### PR DESCRIPTION
Problem

Our Terraform examples using the Terraform Provider's postgres source and destination are outdated and will not run as provided.

The above is caused by changes in the API interface, found in our official Airbyte REST API documentation:

* https://reference.airbyte.com/reference/createsource
* https://reference.airbyte.com/reference/createdestination

These changes are also reflected in the Airbyte Provider documentation:
* https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_postgres
* https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_postgres

Our quickstart Terraform Postgres examples do not sync with changes propogated by SpeakEasy to our REST API and then to the Terraform provider, respectively, so the examples are at least 2 years old.

Solution

- Updates to all **/infra/airbyte/main.tf files in the Quickstarts repository using either the Postgres source or destination Terraform provider API to reflect the latest changes in Airbyte's REST API.

Note

All changes can be rolled back.