### PR TITLE
Claude Agent SDK

### DIFF
--- a/agents_examples/claude_agent_sdk/README.md
+++ b/agents_examples/claude_agent_sdk/README.md
@@ -15,7 +15,6 @@ The agent lives in `airbyte-claude-agent-sdk-example.py`. You can wire each conn
 
 Install the two SDKs and `python-dotenv`:
 
-```bash
 uv add airbyte-agent-sdk claude-agent-sdk python-dotenv
 # or: pip install airbyte-agent-sdk claude-agent-sdk python-dotenv
 ```
@@ -57,7 +56,6 @@ Handlers catch exceptions and return `is_error: True`. When the agent guesses a 
 ## Add connectors
 
 In `main`, add a tuple to the `connectors` list with the following syntax:
-
 ## Files
 
 - `airbyte-claude-agent-sdk-example.py` — the agent.

--- a/agents_examples/claude_agent_sdk/README.md
+++ b/agents_examples/claude_agent_sdk/README.md
@@ -50,7 +50,7 @@ Every Airbyte connector exposes three callables through `build_connector_tools(c
 > [!NOTE]
 > Airbyte Agents SDK offers a function called `build_connector_tools` to encapsulate all three calls for some frameworks. However, The Claude Agent SDK is not one of the frameworks, so the `make_airbyte_tools` helper takes each callable and wraps it as a custom `@tool`. 
 
-Tool names are prefixed per connector (for example `github_execute`) because the three callables share a name across connectors, and all of them register on a single in-process MCP server. `allowed_tools=["mcp__airbyte__*"` pre-approves every tool on that server so none trip a permission prompt.
+Tool names are prefixed per connector (for example `github_execute`) because the three callables share a name across connectors, and all of them register on a single in-process MCP server. `allowed_tools=["mcp__airbyte__*"]` pre-approves every tool on that server so none trip a permission prompt.
 
 Handlers catch exceptions and return `is_error: True`. When the agent guesses a wrong `read_skill_docs` section, the error message carries the valid outline for Claude to read and retry without needing to abort.
 

--- a/agents_examples/claude_agent_sdk/README.md
+++ b/agents_examples/claude_agent_sdk/README.md
@@ -1,0 +1,58 @@
+# Bug-triage agent: Claude Agent SDK + Airbyte Agents
+
+A runnable example agent that reads new GitHub issues, cross-references Linear for duplicates, and posts a triage summary to Slack. It shows how to give a [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) agent live read and write access to your business systems through [Airbyte Agents](https://airbyte.com).
+
+The agent lives in `airbyte-claude-agent-sdk-example.py`. You wire each connector's Airbyte tools into the agent yourself, which gives you full programmatic control.
+
+## Prerequisites
+
+- Python 3.10 or newer. The Claude Agent SDK bundles the Claude Code CLI, so there is nothing else to install for it to run.
+- An Airbyte account with the GitHub, Linear, and Slack connectors connected in your workspace. The Free tier is enough to follow along. Airbyte Agents ships 50+ agent connectors, so you can swap in others; confirm what is live with `list_connectors()`.
+- An Anthropic API key and your Airbyte workspace credentials (see below).
+- `uv` for dependency management. `pip` works too.
+
+## Setup
+
+Install the two SDKs and `python-dotenv`:
+
+```bash
+uv add airbyte-agent-sdk claude-agent-sdk python-dotenv
+# or: pip install airbyte-agent-sdk claude-agent-sdk python-dotenv
+```
+
+Create a `.env` file in the same folder as the script. `connect()` reads the Airbyte variables from the environment automatically, and the Agent SDK reads `ANTHROPIC_API_KEY`.
+
+```
+ANTHROPIC_API_KEY=your_anthropic_key
+AIRBYTE_CLIENT_ID=your_client_id
+AIRBYTE_CLIENT_SECRET=your_client_secret
+AIRBYTE_WORKSPACE_NAME=your_workspace_name
+```
+
+Get the client ID, client secret, and workspace name from your Airbyte workspace.
+
+## Run
+
+```bash
+uv run airbyte-claude-agent-sdk-example.py
+```
+
+The script prints a health line per connector, then streams the agent's work as it reads GitHub and Linear, then posts to Slack.
+
+## How it works
+
+Every Airbyte connector exposes three callables through `build_connector_tools(connector)`: `inspect_connector`, `read_skill_docs`, and `execute`. The agent uses them in a progressive flow instead of loading the whole connector catalog into its prompt up front:
+
+1. `inspect_connector()` reports the connector's metadata and Context Store readiness, and resolves the skill-doc id the other two calls use.
+2. `read_skill_docs()` returns an outline of the connector's entities and actions. `read_skill_docs(section="...")` drills into the guidance for the specific operation the agent is about to run.
+3. `execute(entity, action, params)` runs the operation and returns a structured result with `data` (the records) and `meta` (pagination cursors).
+
+The Claude Agent SDK is not one of the frameworks `build_connector_tools` registers into automatically, so the `make_airbyte_tools` helper takes each callable and wraps it by hand as a custom `@tool`. Tool names are prefixed per connector (for example `github_execute`) because the three callables share a name across connectors, and all of them register on a single in-process MCP server. `allowed_tools=["mcp__airbyte__*"]` pre-approves every tool on that server so none trip a permission prompt.
+
+Handlers catch exceptions and return `is_error: True`. When the agent guesses a wrong `read_skill_docs` section, the error message carries the valid outline, so Claude can read it and retry instead of the run aborting.
+
+## Files
+
+- `airbyte-claude-agent-sdk-example.py` — the agent.
+- `airbyte-claude-agent-sdk-tutorial.md` — full tutorial.
+- `airbyte-claude-agent-sdk-quickstart.md` — five-minute quickstart.

--- a/agents_examples/claude_agent_sdk/README.md
+++ b/agents_examples/claude_agent_sdk/README.md
@@ -55,7 +55,11 @@ Handlers catch exceptions and return `is_error: True`. When the agent guesses a 
 
 ## Add connectors
 
-In `main`, add a tuple to the `connectors` list with the following syntax:
+In `main`, add the name of the connector to the `connectors` list by adding it to the tuple in line `124`:
+
+```python
+    for slug in ("github", "linear", "slack"):
+```
 ## Files
 
 - `airbyte-claude-agent-sdk-example.py` — the agent.

--- a/agents_examples/claude_agent_sdk/README.md
+++ b/agents_examples/claude_agent_sdk/README.md
@@ -2,7 +2,7 @@
 
 A runnable example agent that reads new GitHub issues, cross-references Linear for duplicates, and posts a triage summary to Slack. It shows how to give a [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) agent live read and write access to your business systems through [Airbyte Agents](https://airbyte.com).
 
-The agent lives in `airbyte-claude-agent-sdk-example.py`. You wire each connector's Airbyte tools into the agent yourself, which gives you full programmatic control.
+The agent lives in `airbyte-claude-agent-sdk-example.py`. You can wire each connector's Airbyte tools into the agent yourself, which gives you full programmatic control.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ AIRBYTE_CLIENT_SECRET=your_client_secret
 AIRBYTE_WORKSPACE_NAME=your_workspace_name
 ```
 
-Get the client ID, client secret, and workspace name from your Airbyte workspace.
+Get the client ID, client secret, and workspace name from your Airbyte workspace. If you only have one workspace, this name is `default`.
 
 ## Run
 
@@ -41,18 +41,19 @@ The script prints a health line per connector, then streams the agent's work as 
 
 ## How it works
 
-Every Airbyte connector exposes three callables through `build_connector_tools(connector)`: `inspect_connector`, `read_skill_docs`, and `execute`. The agent uses them in a progressive flow instead of loading the whole connector catalog into its prompt up front:
+Every Airbyte connector exposes three callables through `build_connector_tools(connector)`: `inspect_connector`, `read_skill_docs`, and `execute`. The agent uses them in a progressive flow:
 
-1. `inspect_connector()` reports the connector's metadata and Context Store readiness, and resolves the skill-doc id the other two calls use.
+1. `inspect_connector()` reports the connector's metadata and Context Store readiness, and resolves the skill-doc ID the other two calls use.
 2. `read_skill_docs()` returns an outline of the connector's entities and actions. `read_skill_docs(section="...")` drills into the guidance for the specific operation the agent is about to run.
 3. `execute(entity, action, params)` runs the operation and returns a structured result with `data` (the records) and `meta` (pagination cursors).
 
-The Claude Agent SDK is not one of the frameworks `build_connector_tools` registers into automatically, so the `make_airbyte_tools` helper takes each callable and wraps it by hand as a custom `@tool`. Tool names are prefixed per connector (for example `github_execute`) because the three callables share a name across connectors, and all of them register on a single in-process MCP server. `allowed_tools=["mcp__airbyte__*"]` pre-approves every tool on that server so none trip a permission prompt.
+> [!NOTE]
+> Airbyte Agents SDK offers a function called `build_connector_tools` to encapsulate all three calls for some frameworks. However, The Claude Agent SDK is not one of the frameworks, so the `make_airbyte_tools` helper takes each callable and wraps it as a custom `@tool`. 
 
-Handlers catch exceptions and return `is_error: True`. When the agent guesses a wrong `read_skill_docs` section, the error message carries the valid outline, so Claude can read it and retry instead of the run aborting.
+Tool names are prefixed per connector (for example `github_execute`) because the three callables share a name across connectors, and all of them register on a single in-process MCP server. `allowed_tools=["mcp__airbyte__*"` pre-approves every tool on that server so none trip a permission prompt.
+
+Handlers catch exceptions and return `is_error: True`. When the agent guesses a wrong `read_skill_docs` section, the error message carries the valid outline for Claude to read and retry without needing to abort.
 
 ## Files
 
 - `airbyte-claude-agent-sdk-example.py` — the agent.
-- `airbyte-claude-agent-sdk-tutorial.md` — full tutorial.
-- `airbyte-claude-agent-sdk-quickstart.md` — five-minute quickstart.

--- a/agents_examples/claude_agent_sdk/README.md
+++ b/agents_examples/claude_agent_sdk/README.md
@@ -6,7 +6,7 @@ The agent lives in `airbyte-claude-agent-sdk-example.py`. You can wire each conn
 
 ## Prerequisites
 
-- Python 3.10 or newer. The Claude Agent SDK bundles the Claude Code CLI, so there is nothing else to install for it to run.
+- Python 3.11 or newer. The Claude Agent SDK bundles the Claude Code CLI, so there is nothing else to install for it to run.
 - An Airbyte account with the GitHub, Linear, and Slack connectors connected in your workspace. The Free tier is enough to follow along. Airbyte Agents ships 50+ agent connectors, so you can swap in others; confirm what is live with `list_connectors()`.
 - An Anthropic API key and your Airbyte workspace credentials (see below).
 - `uv` for dependency management. `pip` works too.
@@ -53,6 +53,10 @@ Every Airbyte connector exposes three callables through `build_connector_tools(c
 Tool names are prefixed per connector (for example `github_execute`) because the three callables share a name across connectors, and all of them register on a single in-process MCP server. `allowed_tools=["mcp__airbyte__*"]` pre-approves every tool on that server so none trip a permission prompt.
 
 Handlers catch exceptions and return `is_error: True`. When the agent guesses a wrong `read_skill_docs` section, the error message carries the valid outline for Claude to read and retry without needing to abort.
+
+## Add connectors
+
+In `main`, add a tuple to the `connectors` list with the following syntax:
 
 ## Files
 

--- a/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
+++ b/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
@@ -1,23 +1,14 @@
 """
 Bug-triage agent: Claude Agent SDK + Airbyte Agents (SDK path).
 
-What it does:
-  Reads new GitHub issues, cross-references Linear for duplicates, and posts a
-  triage summary to Slack. Each connector exposes three async methods
-  (inspect_connector, read_skill_docs, execute). We wrap each with Airbyte's
-  agent_tool decorator, which enriches the docstring and steers the model
-  through the inspect -> read docs -> execute flow, then bridge each one into a
-  Claude Agent SDK @tool since the Claude Agent SDK is not a framework
-  agent_tool registers for automatically.
+Reads new GitHub issues, cross-references Linear for duplicates, and posts a
+triage summary to Slack. Each connector exposes three async methods
+(inspect_connector, read_skill_docs, execute) wrapped with Airbyte's
+agent_tool decorator, which enriches the docstring and steers the model
+through the inspect -> read docs -> execute flow. The script then bridges each connection
+into a Claude Agent SDK @tool.
 
-Run it:
-  uv run airbyte-claude-agent-sdk-example.py
-
-Requires a .env with:
-  ANTHROPIC_API_KEY        (the Claude Agent SDK uses this to run Claude)
-  AIRBYTE_CLIENT_ID
-  AIRBYTE_CLIENT_SECRET
-  AIRBYTE_WORKSPACE_NAME
+Run it: uv run airbyte-claude-agent-sdk-example.py
 """
 
 import asyncio
@@ -38,7 +29,7 @@ from claude_agent_sdk import (
 
 load_dotenv()
 
-# The Claude Agent SDK still needs an input schema for each tool, keyed by the
+# Defines a schema for each tool, which will be keyed by the
 # agent_tool role.
 SCHEMAS = {
     "inspect_connector": {"type": "object", "properties": {}},
@@ -78,18 +69,18 @@ def make_airbyte_tools(slug, connector):
     AirbyteToolError. The bridge then adapts the result to the content-array
     shape the Claude Agent SDK expects.
     """
-    # agent_tool is a classmethod on the typed connector class; reach it off the instance.
+    # agent_tool is a class method on the typed connector class; reach it off the instance.
     agent_tool = type(connector).agent_tool
     inspect_name = f"{slug}_inspect"
     docs_name = f"{slug}_read_docs"
     execute_name = f"{slug}_execute"
 
-    @agent_tool()  # role inferred from the empty signature: inspect_connector
+    @agent_tool()  # inspect_connector role inferred from the empty signature
     async def inspect() -> str:
         """Inspect this connector: metadata, Context Store readiness, and its skill-doc id."""
         return json.dumps(await connector.inspect_connector(), default=str)
 
-    @agent_tool()  # role inferred from the section-only signature: read_skill_docs
+    @agent_tool()  # read_skill_docs role inferred from the section-only signature
     async def read_docs(section: str | None = None) -> str:
         """Read the connector's skill docs. Omit the section to get the outline first."""
         return await connector.read_skill_docs(section)

--- a/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
+++ b/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
@@ -3,10 +3,12 @@ Bug-triage agent: Claude Agent SDK + Airbyte Agents (SDK path).
 
 What it does:
   Reads new GitHub issues, cross-references Linear for duplicates, and posts a
-  triage summary to Slack. Each connector exposes three callables through
-  Airbyte's build_connector_tools (inspect_connector, read_skill_docs, execute).
-  The Claude Agent SDK has no built-in integration for them, so we wrap each
-  callable by hand as a custom @tool.
+  triage summary to Slack. Each connector exposes three async methods
+  (inspect_connector, read_skill_docs, execute). We wrap each with Airbyte's
+  agent_tool decorator, which enriches the docstring and steers the model
+  through the inspect -> read docs -> execute flow, then bridge each one into a
+  Claude Agent SDK @tool since the Claude Agent SDK is not a framework
+  agent_tool registers for automatically.
 
 Run it:
   uv run airbyte-claude-agent-sdk-example.py
@@ -20,11 +22,10 @@ Requires a .env with:
 
 import asyncio
 import json
-import os
 
 from dotenv import load_dotenv
 
-from airbyte_agent_sdk import AirbyteAuthConfig, build_connector_tools, connect
+from airbyte_agent_sdk import AirbyteToolError, connect
 from claude_agent_sdk import (
     AssistantMessage,
     ClaudeAgentOptions,
@@ -37,8 +38,9 @@ from claude_agent_sdk import (
 
 load_dotenv()
 
-# Input schemas for Airbyte's three callables, in Claude Agent SDK @tool form.
-TOOL_SCHEMAS = {
+# The Claude Agent SDK still needs an input schema for each tool, keyed by the
+# agent_tool role.
+SCHEMAS = {
     "inspect_connector": {"type": "object", "properties": {}},
     "read_skill_docs": {
         "type": "object",
@@ -69,29 +71,56 @@ TOOL_SCHEMAS = {
 
 
 def make_airbyte_tools(slug, connector):
-    """Wrap a connector's three Airbyte callables as Claude Agent SDK tools.
+    """Wrap a connector's three async methods as Claude Agent SDK tools.
 
-    build_connector_tools returns inspect_connector, read_skill_docs, and execute
-    as plain async callables. We register each by hand because the Claude Agent
-    SDK is not one of build_connector_tools' supported frameworks.
+    agent_tool infers each method's role from its signature, enriches the
+    docstring, and defaults to framework="none" so failures raise
+    AirbyteToolError. The bridge then adapts the result to the content-array
+    shape the Claude Agent SDK expects.
     """
-    callables = {fn.__name__: fn for fn in build_connector_tools(connector).as_list()}
+    # agent_tool is a classmethod on the typed connector class; reach it off the instance.
+    agent_tool = type(connector).agent_tool
+    inspect_name = f"{slug}_inspect"
+    docs_name = f"{slug}_read_docs"
+    execute_name = f"{slug}_execute"
 
-    def wrap(name):
-        underlying = callables[name]
+    @agent_tool()  # role inferred from the empty signature: inspect_connector
+    async def inspect() -> str:
+        """Inspect this connector: metadata, Context Store readiness, and its skill-doc id."""
+        return json.dumps(await connector.inspect_connector(), default=str)
 
-        @tool(f"{slug}_{name}", underlying.__doc__ or name, TOOL_SCHEMAS[name])
+    @agent_tool()  # role inferred from the section-only signature: read_skill_docs
+    async def read_docs(section: str | None = None) -> str:
+        """Read the connector's skill docs. Omit the section to get the outline first."""
+        return await connector.read_skill_docs(section)
+
+    # execute passes its role explicitly and names its siblings, so agent_tool can
+    # steer the model: inspect -> read the outline -> read one section -> execute.
+    @agent_tool("execute", inspect_tool=inspect_name, docs_tool=docs_name)
+    async def execute(entity: str, action: str, params: dict | None = None) -> str:
+        """Run an operation once you've read the relevant skill-doc section."""
+        return json.dumps(await connector.execute(entity, action, params or {}), default=str)
+
+    # Bridge each agent_tool function into a Claude Agent SDK tool. agent_tool has
+    # already enriched __doc__ and set framework="none", so failures arrive as
+    # AirbyteToolError; the bridge adapts the return shape and surfaces errors.
+    def bridge(name, role, fn):
+        @tool(name, fn.__doc__ or name, SCHEMAS[role])
         async def _run(args):
             try:
-                result = await underlying(**args)
-            except Exception as exc:
+                text = await fn(**args)
+            except AirbyteToolError as exc:
                 # Surface the error (e.g. a bad section id) so Claude can retry.
                 return {"content": [{"type": "text", "text": str(exc)}], "is_error": True}
-            return {"content": [{"type": "text", "text": json.dumps(result, default=str)}]}
+            return {"content": [{"type": "text", "text": text}]}
 
         return _run
 
-    return [wrap(name) for name in ("inspect_connector", "read_skill_docs", "execute")]
+    return [
+        bridge(inspect_name, "inspect_connector", inspect),
+        bridge(docs_name, "read_skill_docs", read_docs),
+        bridge(execute_name, "execute", execute),
+    ]
 
 
 async def main():
@@ -116,7 +145,7 @@ async def main():
 
     options = ClaudeAgentOptions(
         mcp_servers={"airbyte": server},
-        allowed_tools=["mcp__airbyte__*"],  # inspect, read_skill_docs, execute for all three
+        allowed_tools=["mcp__airbyte__*"],  # inspect, read_docs, execute for all three
         system_prompt=(
             "You triage engineering bugs. For each connector, inspect it and read its "
             "skill docs to learn the entities and actions before you execute. Check "

--- a/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
+++ b/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
@@ -1,0 +1,146 @@
+"""
+Bug-triage agent: Claude Agent SDK + Airbyte Agents (SDK path).
+
+What it does:
+  Reads new GitHub issues, cross-references Linear for duplicates, and posts a
+  triage summary to Slack. Each connector exposes three callables through
+  Airbyte's build_connector_tools (inspect_connector, read_skill_docs, execute).
+  The Claude Agent SDK has no built-in integration for them, so we wrap each
+  callable by hand as a custom @tool.
+
+Run it:
+  uv run airbyte-claude-agent-sdk-example.py
+
+Requires a .env with:
+  ANTHROPIC_API_KEY        (the Claude Agent SDK uses this to run Claude)
+  AIRBYTE_CLIENT_ID
+  AIRBYTE_CLIENT_SECRET
+  AIRBYTE_WORKSPACE_NAME
+"""
+
+import asyncio
+import json
+import os
+
+from dotenv import load_dotenv
+
+from airbyte_agent_sdk import AirbyteAuthConfig, build_connector_tools, connect
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ResultMessage,
+    TextBlock,
+    create_sdk_mcp_server,
+    query,
+    tool,
+)
+
+load_dotenv()
+
+# Input schemas for Airbyte's three callables, in Claude Agent SDK @tool form.
+TOOL_SCHEMAS = {
+    "inspect_connector": {"type": "object", "properties": {}},
+    "read_skill_docs": {
+        "type": "object",
+        "properties": {
+            "section": {
+                "type": "string",
+                "description": "Section id from the outline. Omit to get the outline itself.",
+            }
+        },
+    },
+    "execute": {
+        "type": "object",
+        "properties": {
+            "entity": {"type": "string", "description": "Entity to operate on, e.g. 'issues'"},
+            "action": {
+                "type": "string",
+                "description": "One of: list, get, create, update, delete, api_search",
+            },
+            "params": {
+                "type": "object",
+                "description": "Parameters for the action (filters, body fields, ids)",
+                "additionalProperties": True,
+            },
+        },
+        "required": ["entity", "action"],
+    },
+}
+
+
+def make_airbyte_tools(slug, connector):
+    """Wrap a connector's three Airbyte callables as Claude Agent SDK tools.
+
+    build_connector_tools returns inspect_connector, read_skill_docs, and execute
+    as plain async callables. We register each by hand because the Claude Agent
+    SDK is not one of build_connector_tools' supported frameworks.
+    """
+    callables = {fn.__name__: fn for fn in build_connector_tools(connector).as_list()}
+
+    def wrap(name):
+        underlying = callables[name]
+
+        @tool(f"{slug}_{name}", underlying.__doc__ or name, TOOL_SCHEMAS[name])
+        async def _run(args):
+            try:
+                result = await underlying(**args)
+            except Exception as exc:
+                # Surface the error (e.g. a bad section id) so Claude can retry.
+                return {"content": [{"type": "text", "text": str(exc)}], "is_error": True}
+            return {"content": [{"type": "text", "text": json.dumps(result, default=str)}]}
+
+        return _run
+
+    return [wrap(name) for name in ("inspect_connector", "read_skill_docs", "execute")]
+
+
+async def main():
+    connectors = (
+        ("github", connect("github")),
+        ("linear", connect("linear")),
+        ("slack", connect("slack")),
+    )
+
+    # Confirm every connection before handing control to the agent.
+    for name, connector in connectors:
+        health = await connector.check()
+        print(f"{name}: {health.status}")
+        if health.status != "healthy":
+            print(f"  {name} is not healthy: {health.error}")
+
+    tools = []
+    for slug, connector in connectors:
+        tools.extend(make_airbyte_tools(slug, connector))
+
+    server = create_sdk_mcp_server(name="airbyte", version="1.0.0", tools=tools)
+
+    options = ClaudeAgentOptions(
+        mcp_servers={"airbyte": server},
+        allowed_tools=["mcp__airbyte__*"],  # inspect, read_skill_docs, execute for all three
+        system_prompt=(
+            "You triage engineering bugs. For each connector, inspect it and read its "
+            "skill docs to learn the entities and actions before you execute. Check "
+            "Linear for duplicates before creating anything, and keep summaries short."
+        ),
+    )
+
+    prompt = (
+        "Look at the GitHub issues opened in the last 24 hours. Check Linear for "
+        "related or duplicate issues, group what you find by severity, and post a "
+        "short triage summary in the #engineering Slack channel."
+    )
+
+    async for message in query(prompt=prompt, options=options):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    print(block.text)
+        elif isinstance(message, ResultMessage) and message.subtype == "success":
+            print(message.result)
+
+    for _, connector in connectors:
+        await connector.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
+++ b/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
@@ -120,6 +120,7 @@ async def main():
     # with any failure during health checks, tool construction, or query streaming.
     connectors = []
     try:
+    # Add more connectors to the agent tools here
         for slug in ("github", "linear", "slack"):
             connectors.append((slug, connect(slug)))
 

--- a/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
+++ b/agents_examples/claude_agent_sdk/airbyte-claude-agent-sdk-example.py
@@ -115,51 +115,53 @@ def make_airbyte_tools(slug, connector):
 
 
 async def main():
-    connectors = (
-        ("github", connect("github")),
-        ("linear", connect("linear")),
-        ("slack", connect("slack")),
-    )
+    # Build connectors incrementally inside the try so that a failure partway
+    # through construction still closes the connectors we already created, along
+    # with any failure during health checks, tool construction, or query streaming.
+    connectors = []
+    try:
+        for slug in ("github", "linear", "slack"):
+            connectors.append((slug, connect(slug)))
 
-    # Confirm every connection before handing control to the agent.
-    for name, connector in connectors:
-        health = await connector.check()
-        print(f"{name}: {health.status}")
-        if health.status != "healthy":
-            print(f"  {name} is not healthy: {health.error}")
+        # Confirm every connection before handing control to the agent.
+        for name, connector in connectors:
+            health = await connector.check()
+            print(f"{name}: {health.status}")
+            if health.status != "healthy":
+                print(f"  {name} is not healthy: {health.error}")
 
-    tools = []
-    for slug, connector in connectors:
-        tools.extend(make_airbyte_tools(slug, connector))
+        tools = []
+        for slug, connector in connectors:
+            tools.extend(make_airbyte_tools(slug, connector))
 
-    server = create_sdk_mcp_server(name="airbyte", version="1.0.0", tools=tools)
+        server = create_sdk_mcp_server(name="airbyte", version="1.0.0", tools=tools)
 
-    options = ClaudeAgentOptions(
-        mcp_servers={"airbyte": server},
-        allowed_tools=["mcp__airbyte__*"],  # inspect, read_docs, execute for all three
-        system_prompt=(
-            "You triage engineering bugs. For each connector, inspect it and read its "
-            "skill docs to learn the entities and actions before you execute. Check "
-            "Linear for duplicates before creating anything, and keep summaries short."
-        ),
-    )
+        options = ClaudeAgentOptions(
+            mcp_servers={"airbyte": server},
+            allowed_tools=["mcp__airbyte__*"],  # inspect, read_docs, execute for all three
+            system_prompt=(
+                "You triage engineering bugs. For each connector, inspect it and read its "
+                "skill docs to learn the entities and actions before you execute. Check "
+                "Linear for duplicates before creating anything, and keep summaries short."
+            ),
+        )
 
-    prompt = (
-        "Look at the GitHub issues opened in the last 24 hours. Check Linear for "
-        "related or duplicate issues, group what you find by severity, and post a "
-        "short triage summary in the #engineering Slack channel."
-    )
+        prompt = (
+            "Look at the GitHub issues opened in the last 24 hours. Check Linear for "
+            "related or duplicate issues, group what you find by severity, and post a "
+            "short triage summary in the #engineering Slack channel."
+        )
 
-    async for message in query(prompt=prompt, options=options):
-        if isinstance(message, AssistantMessage):
-            for block in message.content:
-                if isinstance(block, TextBlock):
-                    print(block.text)
-        elif isinstance(message, ResultMessage) and message.subtype == "success":
-            print(message.result)
-
-    for _, connector in connectors:
-        await connector.close()
+        async for message in query(prompt=prompt, options=options):
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(block.text)
+            elif isinstance(message, ResultMessage) and message.subtype == "success":
+                print(message.result)
+    finally:
+        for _, connector in connectors:
+            await connector.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Showcase how to connect Airbyte Agents SDK to Claude Agent SDK. Companion to a tutorial blog post. Tutorial connects to the following sources through Airbyte:

* GitHub
* Linear
* Slack

It sorts bugs from GitHub and Linear based on priority and posts a triage to Slack. This example uses the new model that breaks `execute()` into the following consecutive commands:

1. `inspect_connector()`
2. `read_skill_docs()`
3. `execute(entity, action, params)`

Claude Agent SDK is not one of the agent frameworks that can use `build_connector_tools()` and therefore needs to call each fucntion.

